### PR TITLE
defer the parsing of httpd messages until after the message is stored…

### DIFF
--- a/td-agent.conf
+++ b/td-agent.conf
@@ -15,9 +15,19 @@
   pos_file /var/log/td-agent/access_log.pos
   tag httpd.access
   <parse>
-    @type apache2
+    @type none
   </parse>
 </source>
+
+<filter httpd.access>
+  @type parser
+  key_name message
+  reserve_data true
+  <parse>
+    @type apache2
+  </parse>
+</filter>
+
 
 <match devel.*>
   @type copy


### PR DESCRIPTION
… (this allows the whole message to appear in graylog, as well as being parsed)